### PR TITLE
Feature/devops 484

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
 		php-bcmath    \
 		php-mbstring  \
 		php-gd        \
+		php-imagick   \
 		mc            \
 		sudo          \
     && apt-get -y clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,67 @@
 FROM ubuntu:xenial
 
-RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
-RUN apt-get update && \
-    apt-get install -y ant && \
-    apt-get install -y git && \
-    apt-get install -y curl && \
-    apt-get purge -y php5* && \
-    apt-get install -y php7.0 && \
-    apt-get install -y php7.0-dev && \
-    apt-get install -y php7.0-curl && \
-    apt-get install -y php7.0-intl && \
-    apt-get install -y php-mysql && \
-    apt-get install -y php-redis && \
-    apt-get install -y php-bcmath && \
-    apt-get install -y php-mbstring && \
-    apt-get install -y php-gd && \
-    apt-get install -y mc && \
-    apt-get install -y cron && \
-    apt-get install -y sudo && \
-    apt-get install -y vim && \
-    apt-get install nodejs npm -y && \
-    apt-get install supervisor -y
+ENV REFRESHED_AT "2016-06-23 14:04:00"
 
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get purge -y php5* && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -q \ 
+        ant           \
+        git           \
+        curl          \
+        php7.0        \
+        php7.0-dev    \
+        php7.0-curl   \
+        php7.0-intl   \
+        php-mysql     \
+		php-redis     \
+		php-bcmath    \
+		php-mbstring  \
+		php-gd        \
+		mc            \
+		sudo          \
+        nodejs        \
+        npm           
+
+
+# gosu is used insted of sudo and exec to ensure the container process get pid 1
+RUN curl -o /usr/bin/gosu -fsSL "https://github.com/tianon/gosu/releases/download/1.9/gosu-$(dpkg --print-architecture)" && \
+    chmod +x /usr/bin/gosu
+
+RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
 RUN ln -s /usr/bin/nodejs /usr/bin/node
+
 RUN yes '' | pecl install apcu_bc-beta
+
+RUN curl -sS https://getcomposer.org/installer | php
+RUN mv composer.phar /usr/local/bin/composer
 
 RUN echo 'extension=apcu.so' >> /etc/php/7.0/cli/php.ini && \
     echo 'extension=apc.so' >> /etc/php/7.0/cli/php.ini && \
     echo 'extension=apcu.so' >> /etc/php/7.0/fpm/php.ini && \
     echo 'extension=apc.so' >> /etc/php/7.0/fpm/php.ini
 
-ADD opcache.ini /etc/php/7.0/fpm/conf.d/
+ADD opcache.ini /etc/php/7.0/mods-available/opcache.ini
 
 ADD symfony.pool.conf /etc/php/7.0/fpm/pool.d/
 
-RUN curl -sS https://getcomposer.org/installer | php
-RUN mv composer.phar /usr/local/bin/composer
+RUN sed -i -e "s/^error_log =/;error_log =/" /etc/php/7.0/fpm/php-fpm.conf && \
+    sed -i -e "s/;daemonize = yes/daemonize = no/" /etc/php/7.0/fpm/php-fpm.conf && \
+    sed -i -e "/^;error_log =/ a \
+error_log = /proc/self/fd/2 " /etc/php/7.0/fpm/php-fpm.conf 
+
+RUN mkdir -p /run/php/ && \
+    touch /run/php/php7.0-fpm.sock
+
+# Cleanup - Remove cache and temporary files - no need to spend storage on cache 
+RUN apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+EXPOSE 9000 3000
 
 ADD runit.sh /
 
-CMD ["/runit.sh"]
+ENTRYPOINT ["/runit.sh"]
+
+CMD ["php-fpm7.0", "--nodaemonize", "--fpm-config", "/etc/php/7.0/fpm/php-fpm.conf"]
 
 WORKDIR /var/www

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,11 @@ FROM ubuntu:xenial
 
 ENV REFRESHED_AT "2016-06-23 14:04:00"
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get purge -y php5* && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -q \ 
-        ant           \
-        git           \
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get purge -y php5*  \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y -q \
         curl          \
+        wget          \
         php7.0        \
         php7.0-dev    \
         php7.0-curl   \
@@ -19,21 +18,42 @@ RUN apt-get update && \
 		php-gd        \
 		mc            \
 		sudo          \
-        nodejs        \
-        npm           
+    && apt-get -y clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
 # gosu is used insted of sudo and exec to ensure the container process get pid 1
-RUN curl -o /usr/bin/gosu -fsSL "https://github.com/tianon/gosu/releases/download/1.9/gosu-$(dpkg --print-architecture)" && \
-    chmod +x /usr/bin/gosu
+ENV GOSU_VERSION 1.9
+RUN set -x \
+    && apt-get update && apt-get install -y --no-install-recommends ca-certificates wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
+    && wget -O /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
+    && wget -O /usr/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && gpg --batch --verify /usr/bin/gosu.asc /usr/bin/gosu \
+    && rm -r "$GNUPGHOME" /usr/bin/gosu.asc \
+    && chmod +x /usr/bin/gosu \
+    && gosu nobody true \
+    && apt-get -y clean
 
-RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
-RUN ln -s /usr/bin/nodejs /usr/bin/node
+#RUN curl -sL https://deb.nodesource.com/setup_4.x | bash - \
+#    && ln -s /usr/bin/nodejs /usr/bin/node
 
-RUN yes '' | pecl install apcu_bc-beta
+# Install apcu_bc-beta
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y -q \
+       php-pear \
+       make     \
+    && rm -rf /var/lib/apt/lists/* \
+    && yes '' | pecl install apcu_bc-beta \
+    && apt-get -y purge php-pear make \
+    && apt-get -y clean
 
-RUN curl -sS https://getcomposer.org/installer | php
-RUN mv composer.phar /usr/local/bin/composer
+
+RUN curl -sS https://getcomposer.org/installer | php \
+    && mv composer.phar /usr/local/bin/composer
 
 RUN echo 'extension=apcu.so' >> /etc/php/7.0/cli/php.ini && \
     echo 'extension=apc.so' >> /etc/php/7.0/cli/php.ini && \
@@ -42,19 +62,20 @@ RUN echo 'extension=apcu.so' >> /etc/php/7.0/cli/php.ini && \
 
 ADD opcache.ini /etc/php/7.0/mods-available/opcache.ini
 
+# Add empty ini file. Enables config runtime overriding of parameters
+RUN touch /etc/php/7.0/mods-available/devops.ini \
+    && ln -s /etc/php/7.0/mods-available/devops.ini /etc/php/7.0/fpm/conf.d/99-devops.ini \
+    && ln -s /etc/php/7.0/mods-available/devops.ini /etc/php/7.0/cli/conf.d/99-devops.ini
+
 ADD symfony.pool.conf /etc/php/7.0/fpm/pool.d/
 
 RUN sed -i -e "s/^error_log =/;error_log =/" /etc/php/7.0/fpm/php-fpm.conf && \
     sed -i -e "s/;daemonize = yes/daemonize = no/" /etc/php/7.0/fpm/php-fpm.conf && \
     sed -i -e "/^;error_log =/ a \
-error_log = /proc/self/fd/2 " /etc/php/7.0/fpm/php-fpm.conf 
+error_log = /proc/self/fd/2 " /etc/php/7.0/fpm/php-fpm.conf
 
 RUN mkdir -p /run/php/ && \
     touch /run/php/php7.0-fpm.sock
-
-# Cleanup - Remove cache and temporary files - no need to spend storage on cache 
-RUN apt-get -y clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 EXPOSE 9000 3000
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ By default it will start php-fpm and listen on port 9000.
 
 If you want to run a consumer/worker it can be started linke this:
 
-docker run -d bm.docker.php7 php app/console sqs:multiple-consumer --env=prod -q <consumername>
+docker run --restart=always -d bm.docker.php7 php bin/console sqs:multiple-consumer --env=prod -q <consumername>
 
 Each worker/consumer must run in its own container and the process must stay in foreground (ie. should not deamonize)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # bm.docker.php7
 Docker for php7
+
+
+This image can run both php-fpm and php cli for consumers.
+
+By default it will start php-fpm and listen on port 9000.
+
+
+If you want to run a consumer/worker it can be started linke this:
+
+docker run -d bm.docker.php7 php app/console sqs:multiple-consumer --env=prod -q <consumername>
+
+Each worker/consumer must run in its own container and the process must stay in foreground (ie. should not deamonize)

--- a/runit.sh
+++ b/runit.sh
@@ -1,18 +1,31 @@
 #!/bin/bash
+set -e
 
-if [ -z "${USER_ID}" ]; then
-       USER_ID=1000
+USER_ID=${USER_ID:-"www-data"}
+GROUP_ID=${GROUP_ID:-$USER_ID}
+
+if [[ "$1" == 'php-fpm' || "$1" == 'php-fpm7.0' ]]; then
+    shift 1
+    echo "Running php-fpm7.0 $@"
+
+    # Set user and group for php-fpm process
+    if ! [ "$USER_ID" == 'www-data' ] ; then 
+        sed -i -e "s/^user = .*/user = $USER_ID/"    /etc/php/7.0/fpm/pool.d/symfony.pool.conf
+        sed -i -e "s/^group = .*/group = $GROUP_ID/" /etc/php/7.0/fpm/pool.d/symfony.pool.conf
+    fi
+
+    exec php-fpm7.0 "$@"
+
+elif [[ "$1" == 'php' || "$1" == 'php7.0' ]]; then 
+    shift 1
+    echo "Running cli: php7.0 $@"
+    exec gosu $USER_ID:$GROUP_ID php7.0 "$@"
+
+else 
+    echo "Running command: $@"
+    exec "$@"   
+
 fi
 
-usermod -u $USER_ID www-data
-groupmod -g $USER_ID www-data
 
-echo "Starting supervisor:"
-/usr/bin/supervisord -c /etc/supervisor/supervisord.conf
 
-echo "Starting cron:"
-cron
-
-while true; do
-    /etc/init.d/php7.0-fpm start
-done

--- a/symfony.pool.conf
+++ b/symfony.pool.conf
@@ -43,7 +43,7 @@ listen = 0.0.0.0:9000
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = static
+pm = ondemand
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
@@ -54,22 +54,9 @@ pm = static
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 10
-
-; The number of child processes created on startup.
-; Note: Used only when pm is set to 'dynamic'
-; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
-pm.start_servers = 10
-
-; The desired minimum number of idle server processes.
-; Note: Used only when pm is set to 'dynamic'
-; Note: Mandatory when pm is set to 'dynamic'
-pm.min_spare_servers = 1
-
-; The desired maximum number of idle server processes.
-; Note: Used only when pm is set to 'dynamic'
-; Note: Mandatory when pm is set to 'dynamic'
-pm.max_spare_servers = 5
+pm.max_children = 16
+pm.process_idle_timeout = 60s
+pm.max_requests = 200
 
 ;---------------------
 


### PR DESCRIPTION
Revorked image significantly. 

Removed cron and supervisord.

Updated runit.sh 
- remove supervisord (consumers should run in seperate containers, see README.md) 
- remove cron. cron should not execute inside this container.
- execute just one process - either php-fpm or php cli.

Expose ports

Use ENTRYPOINT for runit.sh
Use CMD for execurint php-fpm by default

Allow php-fpm to run as a different user (this i a suggested alternative to usermod/groupmod)

Use gosu to execute php cli as different user

Change php-fpm pool config to ondemand process manager
